### PR TITLE
Fix test suite commands not working on fresh clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ as a Git submodule. `ec4rs` should pass all of these tests.
 To run the test suite, run the following commands in a POSIX-like shell:
 
 ```bash
-cargo build -p ec4rs_tools
-cmake -DEDITORCONFIG_CMD="$PWD/target/debug/ec4rs-parse" tests
+cargo build --package ec4rs_tools
+git submodule update --init --recursive
+cmake -DEDITORCONFIG_CMD="$PWD/target/debug/ec4rs-parse" -Stests -Btests
 ctest --test-dir tests
 ```


### PR DESCRIPTION
CMake remembers where the build directory is on subsequent invocations, so the previous commands worked when a build system was already generated but not on a fresh clone.

Also added the git-submodule command for convenience and used long flags where possible.