### PR TITLE
Remove `off` variant from `MaxLineLen` property

### DIFF
--- a/src/property.rs
+++ b/src/property.rs
@@ -148,7 +148,7 @@ property_choice! {
 
 property_valued! {TrimTrailingWs, "trim_trailing_whitespace", bool;}
 property_valued! {FinalNewline, "insert_final_newline", bool;}
-property_valued! {MaxLineLen, "max_line_length", usize; (Off, "off")}
+property_valued! {MaxLineLen, "max_line_length", usize;}
 
 // As of the authorship of this comment, spelling_language isn't on the wiki.
 // Ooop.


### PR DESCRIPTION
Part of https://github.com/TheDaemoness/ec4rs/issues/17

Based on https://github.com/editorconfig/editorconfig/discussions/556 which explains that `off` is not a valid value and `unset` should be used instead.